### PR TITLE
fix(plugin): YAML frontmatter fix and add codespell CI

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,21 @@
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          check_filenames: true
+          skip: .git,go.sum

--- a/plugins/taskledger/commands/update-jira.md
+++ b/plugins/taskledger/commands/update-jira.md
@@ -1,6 +1,6 @@
 ---
 description: Post work report comments to JIRA tickets from worklog.yml
-argument-hint: [--file PATH] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--dry-run]
+argument-hint: "[--file PATH] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--dry-run]"
 ---
 
 ## Name


### PR DESCRIPTION
## Summary
- Fix YAML parsing error on GitHub by quoting the `argument-hint` value in frontmatter
- Add codespell GitHub Action workflow for spell checking on PRs and pushes to main

## Test plan
- [ ] Verify the update-jira.md file renders correctly on GitHub without YAML parsing errors
- [ ] Verify the codespell workflow runs successfully

🤖 Generated with [Claude Code](https://claude.ai/code)