### PR TITLE
fix(report): detect freeform text as non-feature work

### DIFF
--- a/internal/report/categorize.go
+++ b/internal/report/categorize.go
@@ -4,18 +4,24 @@ package report
 import (
 	"strings"
 
+	"github.com/bryan-cox/taskledger/internal/jira"
 	"github.com/bryan-cox/taskledger/internal/model"
 )
 
 // IsNonFeatureWork returns true if the task should be grouped under "Non-feature work".
 // A task is non-feature work if:
 // - jira_ticket is empty, OR
-// - jira_ticket contains "NO-JIRA" AND github_pr is empty
+// - jira_ticket contains "NO-JIRA" AND github_pr is empty, OR
+// - jira_ticket does NOT contain a valid JIRA ticket pattern (PROJ-123)
 func IsNonFeatureWork(ticket string, githubPR string) bool {
 	if ticket == "" {
 		return true
 	}
 	if strings.Contains(strings.ToUpper(ticket), "NO-JIRA") && githubPR == "" {
+		return true
+	}
+	// Reuse existing jira.ExtractTicketID to check for valid JIRA pattern
+	if jira.ExtractTicketID(ticket) == "" {
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
- Update `IsNonFeatureWork` to detect tasks that don't contain a valid JIRA ticket pattern
- Freeform text like "HCM interview prep" or "Updated taskledger" are now correctly grouped under "Non-feature work"
- Reuses existing `jira.ExtractTicketID()` function following DRY principles

## Test plan
- [x] All existing tests pass (`make test`)
- [x] Generated HTML report correctly groups freeform text under "Non-feature work"
- [ ] Verify in production with real worklog data

🤖 Generated with [Claude Code](https://claude.com/claude-code)