### PR TITLE
feat(report): add --jira-summaries flag for pre-fetched ticket info

### DIFF
--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -19,10 +19,16 @@ const (
 )
 
 // GenerateHTML creates an HTML version of the report.
-func GenerateHTML(dates []string, completedTasks map[string][]model.TaskWithDate, nextUpTasks map[string][]model.TaskWithDate, blockedTasks []model.Task) string {
-	// Process JIRA tickets and fetch summaries
-	allTickets := collectAllTickets(completedTasks, nextUpTasks, blockedTasks)
-	jiraInfo := jira.ProcessTickets(allTickets)
+// If preloadedJiraInfo is provided (non-nil), it will be used instead of fetching from JIRA API.
+func GenerateHTML(dates []string, completedTasks map[string][]model.TaskWithDate, nextUpTasks map[string][]model.TaskWithDate, blockedTasks []model.Task, preloadedJiraInfo map[string]jira.TicketInfo) string {
+	// Use preloaded JIRA info if provided, otherwise fetch from API
+	var jiraInfo map[string]jira.TicketInfo
+	if preloadedJiraInfo != nil {
+		jiraInfo = preloadedJiraInfo
+	} else {
+		allTickets := collectAllTickets(completedTasks, nextUpTasks, blockedTasks)
+		jiraInfo = jira.ProcessTickets(allTickets)
+	}
 
 	var htmlBuilder strings.Builder
 


### PR DESCRIPTION
## Summary
- Add `--jira-summaries` flag to report command to load JIRA ticket summaries from a JSON file
- Add `jira.LoadSummariesFromFile()` function to parse pre-fetched summaries
- Update `GenerateHTML` to accept optional pre-loaded JIRA info
- Update html-report plugin to fetch summaries via MCP before generating report

This enables the MCP plugin to fetch ticket summaries using the Atlassian MCP server and pass them to the binary, so reports include ticket titles even without `JIRA_PAT` configured.

## Test plan
- [x] All tests pass (`make test`)
- [x] Binary builds successfully (`make build`)
- [ ] Run `/taskledger:html-report` to verify JIRA summaries are fetched via MCP
- [ ] Verify HTML report includes ticket summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)