### PR TITLE
fix(report): improve non-feature work grouping with sub-entries

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -181,13 +181,17 @@ func TestReportCommand(t *testing.T) {
 		if !strings.Contains(output, "• Non-feature work:") {
 			t.Error("Report should include 'Non-feature work' header for tasks without Jira tickets")
 		}
-		if !strings.Contains(output, "◦ Organized project documentation and created initial README.") {
+		// Non-feature work items with empty tickets are grouped under "Misc"
+		if !strings.Contains(output, "◦ Misc") {
+			t.Error("Report should include 'Misc' sub-header for tasks without Jira tickets")
+		}
+		if !strings.Contains(output, "▪ Organized project documentation and created initial README.") {
 			t.Error("Report should include completed task that has no Jira ticket under Non-feature work")
 		}
-		if !strings.Contains(output, "◦ Updated team wiki with new development processes.") {
+		if !strings.Contains(output, "▪ Updated team wiki with new development processes.") {
 			t.Error("Report should include completed task that has no Jira ticket under Non-feature work")
 		}
-		if !strings.Contains(output, "◦ Run linter and fix all warnings") {
+		if !strings.Contains(output, "▪ Run linter and fix all warnings") {
 			t.Error("Report should include next up task that has no Jira ticket under Non-feature work")
 		}
 		// Check for PR links for tasks without Jira tickets

--- a/internal/report/categorize.go
+++ b/internal/report/categorize.go
@@ -12,13 +12,16 @@ import (
 // A task is non-feature work if:
 // - jira_ticket is empty, OR
 // - jira_ticket contains "NO-JIRA" AND github_pr is empty, OR
-// - jira_ticket does NOT contain a valid JIRA ticket pattern (PROJ-123)
+// - jira_ticket does NOT contain a valid JIRA ticket pattern (PROJ-123) AND does NOT contain "NO-JIRA"
+//
+// Note: NO-JIRA with a PR is considered feature work (shown as its own entry, not under non-feature)
 func IsNonFeatureWork(ticket string, githubPR string) bool {
 	if ticket == "" {
 		return true
 	}
-	if strings.Contains(strings.ToUpper(ticket), "NO-JIRA") && githubPR == "" {
-		return true
+	// NO-JIRA items: non-feature only if no PR, otherwise feature work
+	if strings.Contains(strings.ToUpper(ticket), "NO-JIRA") {
+		return githubPR == ""
 	}
 	// Reuse existing jira.ExtractTicketID to check for valid JIRA pattern
 	if jira.ExtractTicketID(ticket) == "" {

--- a/plugins/taskledger/.claude-plugin/plugin.json
+++ b/plugins/taskledger/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "taskledger",
   "description": "Track work progress and sync status updates to JIRA tickets from worklog.yml files",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "Bryan Cox"
   }


### PR DESCRIPTION
## Summary
- Fix `IsNonFeatureWork` logic: NO-JIRA with PR is now treated as feature work (shown as its own top-level entry, not under Non-feature work)
- Non-feature work items are now grouped under a "Non-feature work" header with sub-entries
- Each non-feature ticket becomes a sub-entry with its descriptions as third-level bullets
- Empty tickets are grouped under "Misc"
- Applies to both HTML and text report rendering

## Example output

Before:
```
• Non-feature work:
    ◦ Prepared for interview
    ◦ Conducted interview
    ◦ Added GitHub Action tests
```

After:
```
• Non-feature work:
    ◦ HCM interview prep
        ▪ Prepared for interview
        ▪ Conducted interview
    ◦ Updated taskledger
        ▪ Added GitHub Action tests
```

## Test plan
- [x] All tests pass (`make test`)
- [x] Generated report correctly shows NO-JIRA with PR as top-level entry
- [x] Generated report correctly groups non-feature items with sub-entries
- [x] HTML and text reports have consistent structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)