### PR TITLE
fix(report): separate non-feature items and flatten HTML for Slack

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -178,20 +178,17 @@ func TestReportCommand(t *testing.T) {
 			t.Error("Report missing GitHub PR link")
 		}
 		// Check for non-feature work grouping (tasks without Jira tickets)
-		if !strings.Contains(output, "• Non-feature work:") {
+		if !strings.Contains(output, "• Non-feature work") {
 			t.Error("Report should include 'Non-feature work' header for tasks without Jira tickets")
 		}
-		// Non-feature work items with empty tickets are grouped under "Misc"
-		if !strings.Contains(output, "◦ Misc") {
-			t.Error("Report should include 'Misc' sub-header for tasks without Jira tickets")
+		// Non-feature work items are now shown as individual sub-entries with first description as header
+		if !strings.Contains(output, "◦ Organized project documentation and created initial README.") {
+			t.Error("Report should include completed task with PR as its own sub-entry under Non-feature work")
 		}
-		if !strings.Contains(output, "▪ Organized project documentation and created initial README.") {
-			t.Error("Report should include completed task that has no Jira ticket under Non-feature work")
+		if !strings.Contains(output, "◦ Updated team wiki with new development processes.") {
+			t.Error("Report should include completed task without PR as its own sub-entry under Non-feature work")
 		}
-		if !strings.Contains(output, "▪ Updated team wiki with new development processes.") {
-			t.Error("Report should include completed task that has no Jira ticket under Non-feature work")
-		}
-		if !strings.Contains(output, "▪ Run linter and fix all warnings") {
+		if !strings.Contains(output, "◦ Run linter and fix all warnings") {
 			t.Error("Report should include next up task that has no Jira ticket under Non-feature work")
 		}
 		// Check for PR links for tasks without Jira tickets

--- a/internal/report/categorize.go
+++ b/internal/report/categorize.go
@@ -2,6 +2,7 @@
 package report
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/bryan-cox/taskledger/internal/jira"
@@ -19,6 +20,10 @@ func IsNonFeatureWork(ticket string, githubPR string) bool {
 	if ticket == "" {
 		return true
 	}
+	// Synthetic keys from categorization are always non-feature work
+	if IsSyntheticKey(ticket) {
+		return true
+	}
 	// NO-JIRA items: non-feature only if no PR, otherwise feature work
 	if strings.Contains(strings.ToUpper(ticket), "NO-JIRA") {
 		return githubPR == ""
@@ -30,8 +35,11 @@ func IsNonFeatureWork(ticket string, githubPR string) bool {
 	return false
 }
 
-// emptyTicketKey is a placeholder key for tasks without JIRA tickets.
-const emptyTicketKey = "__empty__"
+// IsSyntheticKey returns true if the key is a generated grouping key (not a real ticket name).
+// Synthetic keys are used for tasks without JIRA tickets, grouped by PR URL or unique counter.
+func IsSyntheticKey(key string) bool {
+	return strings.HasPrefix(key, "__noticket_") || strings.HasPrefix(key, "http://") || strings.HasPrefix(key, "https://")
+}
 
 // CategorizeTasks groups tasks from the work data into completed, next up, and blocked categories.
 func CategorizeTasks(workData model.WorkData, dates []string) model.CategorizedTasks {
@@ -39,6 +47,7 @@ func CategorizeTasks(workData model.WorkData, dates []string) model.CategorizedT
 	allNextUpTasks := make(map[string][]model.TaskWithDate)
 	mostRecentTasks := make(map[string]model.TaskWithDate)
 
+	emptyCounter := 0
 	for _, date := range dates {
 		dailyLog, exists := workData[date]
 		if !exists {
@@ -48,38 +57,42 @@ func CategorizeTasks(workData model.WorkData, dates []string) model.CategorizedT
 			taskWithDate := model.TaskWithDate{Task: task, Date: date}
 			jiraTicket := task.JiraTicket
 
+			// Compute grouping key: for tasks without a JIRA ticket, group by PR URL
+			// or assign a unique key so they don't all merge under one entry
+			groupKey := jiraTicket
+			if jiraTicket == "" {
+				if task.GithubPR != "" {
+					groupKey = task.GithubPR
+				} else {
+					groupKey = fmt.Sprintf("__noticket_%d__", emptyCounter)
+					emptyCounter++
+				}
+			}
+
 			// Track completed tasks - include both completed and in-progress tasks with descriptions
 			if strings.EqualFold(task.Status, model.StatusCompleted) ||
 				(strings.EqualFold(task.Status, model.StatusInProgress) && len(task.GetDescriptions()) > 0) {
-				completedTasks[jiraTicket] = append(completedTasks[jiraTicket], taskWithDate)
+				completedTasks[groupKey] = append(completedTasks[groupKey], taskWithDate)
 			}
 
 			// Collect all tasks with upnext descriptions
 			if task.UpnextDescription != "" {
-				allNextUpTasks[jiraTicket] = append(allNextUpTasks[jiraTicket], taskWithDate)
+				allNextUpTasks[groupKey] = append(allNextUpTasks[groupKey], taskWithDate)
 			}
 
-			// Track most recent task per Jira ticket
-			taskKey := jiraTicket
-			if taskKey == "" {
-				taskKey = emptyTicketKey
-			}
-			if existing, exists := mostRecentTasks[taskKey]; !exists || date > existing.Date {
-				mostRecentTasks[taskKey] = taskWithDate
+			// Track most recent task per group
+			if existing, exists := mostRecentTasks[groupKey]; !exists || date > existing.Date {
+				mostRecentTasks[groupKey] = taskWithDate
 			}
 		}
 	}
 
 	// Filter next up tasks: only include tickets where the most recent task is still in progress or not started
 	nextUpTasks := make(map[string][]model.TaskWithDate)
-	for jiraTicket, taskList := range allNextUpTasks {
-		taskKey := jiraTicket
-		if taskKey == "" {
-			taskKey = emptyTicketKey
-		}
-		if mostRecent, exists := mostRecentTasks[taskKey]; exists {
+	for groupKey, taskList := range allNextUpTasks {
+		if mostRecent, exists := mostRecentTasks[groupKey]; exists {
 			if strings.EqualFold(mostRecent.Status, model.StatusInProgress) || strings.EqualFold(mostRecent.Status, model.StatusNotStarted) {
-				nextUpTasks[jiraTicket] = taskList
+				nextUpTasks[groupKey] = taskList
 			}
 		}
 	}

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -18,6 +18,13 @@ const (
 	htmlNonFeatureWorkHeader = `Non-feature work`
 )
 
+// Inline bullet characters used instead of nested <ul> for Slack compatibility.
+// Indentation uses &nbsp; to create visual hierarchy when pasted into Slack.
+const (
+	bulletL2 = `&nbsp;&nbsp;&nbsp;◦ `       // Second-level bullet (descriptions under tickets)
+	bulletL3 = `&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- ` // Third-level bullet (descriptions under non-feature sub-entries)
+)
+
 // GenerateHTML creates an HTML version of the report.
 // If preloadedJiraInfo is provided (non-nil), it will be used instead of fetching from JIRA API.
 func GenerateHTML(dates []string, completedTasks map[string][]model.TaskWithDate, nextUpTasks map[string][]model.TaskWithDate, blockedTasks []model.Task, preloadedJiraInfo map[string]jira.TicketInfo) string {
@@ -71,8 +78,8 @@ func collectAllTickets(completed map[string][]model.TaskWithDate, nextUp map[str
 	return allTickets
 }
 
-// renderPRLinksHTML renders a list of PR links as HTML.
-func renderPRLinksHTML(prLinks map[string]bool) string {
+// renderPRLinksInline renders PR links as inline text with a <br/> prefix and bullet character.
+func renderPRLinksInline(prLinks map[string]bool, bullet string) string {
 	if len(prLinks) == 0 {
 		return ""
 	}
@@ -84,14 +91,13 @@ func renderPRLinksHTML(prLinks map[string]bool) string {
 	sort.Strings(links)
 
 	var sb strings.Builder
-	sb.WriteString(`<li>PR(s): `)
+	sb.WriteString(fmt.Sprintf(`<br/>%sPR(s): `, bullet))
 	for i, link := range links {
 		if i > 0 {
 			sb.WriteString("; ")
 		}
 		sb.WriteString(fmt.Sprintf(`<a href="%s">%s</a>`, html.EscapeString(link), html.EscapeString(link)))
 	}
-	sb.WriteString(`</li>`)
 	return sb.String()
 }
 
@@ -111,7 +117,6 @@ func renderCompletedTasksHTML(tasks map[string][]model.TaskWithDate, jiraInfo ma
 
 	for ticket := range tasks {
 		taskList := tasks[ticket]
-		// Check if any task in the group has a PR (for NO-JIRA check)
 		hasPR := false
 		for _, t := range taskList {
 			if t.GithubPR != "" {
@@ -139,21 +144,20 @@ func renderCompletedTasksHTML(tasks map[string][]model.TaskWithDate, jiraInfo ma
 		sb.WriteString(renderTicketEntryHTML(ticket, tasks[ticket], jiraInfo))
 	}
 
-	// Render non-feature work at the end (grouped under "Non-feature work" with sub-entries)
+	// Render non-feature work grouped under "Non-feature work"
 	if len(nonFeatureTickets) > 0 {
 		sb.WriteString(fmt.Sprintf(`<li><strong>%s</strong>`, htmlNonFeatureWorkHeader))
-		sb.WriteString(`<ul>`)
 		for _, ticket := range nonFeatureTickets {
 			sb.WriteString(renderNonFeatureSubEntryHTML(ticket, tasks[ticket]))
 		}
-		sb.WriteString(`</ul></li>`)
+		sb.WriteString(`</li>`)
 	}
 
 	sb.WriteString(`</ul>`)
 	return sb.String()
 }
 
-// renderTicketEntryHTML renders a single ticket entry with its descriptions and PRs.
+// renderTicketEntryHTML renders a single ticket entry with descriptions and PRs as inline <br/> items.
 func renderTicketEntryHTML(ticket string, taskList []model.TaskWithDate, jiraInfo map[string]jira.TicketInfo) string {
 	sort.Slice(taskList, func(i, j int) bool {
 		return taskList[i].Date < taskList[j].Date
@@ -172,17 +176,16 @@ func renderTicketEntryHTML(ticket string, taskList []model.TaskWithDate, jiraInf
 		}
 	}
 
-	sb.WriteString(`<ul>`)
 	for _, desc := range descriptions {
-		sb.WriteString(fmt.Sprintf(`<li>%s</li>`, html.EscapeString(desc)))
+		sb.WriteString(fmt.Sprintf(`<br/>%s%s`, bulletL2, html.EscapeString(desc)))
 	}
-	sb.WriteString(renderPRLinksHTML(prLinks))
-	sb.WriteString(`</ul></li>`)
+	sb.WriteString(renderPRLinksInline(prLinks, bulletL2))
+	sb.WriteString(`</li>`)
 
 	return sb.String()
 }
 
-// renderNonFeatureSubEntryHTML renders a non-feature work sub-entry with ticket name as header and descriptions as nested bullets.
+// renderNonFeatureSubEntryHTML renders a non-feature work sub-entry using <br/> for Slack compatibility.
 func renderNonFeatureSubEntryHTML(ticket string, taskList []model.TaskWithDate) string {
 	sort.Slice(taskList, func(i, j int) bool {
 		return taskList[i].Date < taskList[j].Date
@@ -200,22 +203,23 @@ func renderNonFeatureSubEntryHTML(ticket string, taskList []model.TaskWithDate) 
 
 	var sb strings.Builder
 
-	// Use ticket text as the sub-entry header (or "Misc" if empty)
+	// Determine header: for synthetic keys (PR URLs, __noticket_N__), use the first description
 	header := ticket
-	if header == "" {
-		header = "Misc"
-	}
-	sb.WriteString(fmt.Sprintf(`<li>%s`, html.EscapeString(header)))
-
-	if len(descriptions) > 0 || len(prLinks) > 0 {
-		sb.WriteString(`<ul>`)
-		for _, desc := range descriptions {
-			sb.WriteString(fmt.Sprintf(`<li>%s</li>`, html.EscapeString(desc)))
+	if IsSyntheticKey(ticket) || header == "" {
+		if len(descriptions) > 0 {
+			header = descriptions[0]
+			descriptions = descriptions[1:]
+		} else {
+			header = "Misc"
 		}
-		sb.WriteString(renderPRLinksHTML(prLinks))
-		sb.WriteString(`</ul>`)
 	}
-	sb.WriteString(`</li>`)
+	sb.WriteString(fmt.Sprintf(`<br/>%s%s`, bulletL2, html.EscapeString(header)))
+
+	sort.Strings(descriptions)
+	for _, desc := range descriptions {
+		sb.WriteString(fmt.Sprintf(`<br/>%s%s`, bulletL3, html.EscapeString(desc)))
+	}
+	sb.WriteString(renderPRLinksInline(prLinks, bulletL3))
 
 	return sb.String()
 }
@@ -236,7 +240,6 @@ func renderNextUpTasksHTML(tasks map[string][]model.TaskWithDate, jiraInfo map[s
 
 	for ticket := range tasks {
 		taskList := tasks[ticket]
-		// Check if any task in the group has a PR (for NO-JIRA check)
 		hasPR := false
 		for _, t := range taskList {
 			if t.GithubPR != "" {
@@ -264,21 +267,20 @@ func renderNextUpTasksHTML(tasks map[string][]model.TaskWithDate, jiraInfo map[s
 		sb.WriteString(renderNextUpTicketEntryHTML(ticket, tasks[ticket], jiraInfo))
 	}
 
-	// Render non-feature work at the end (grouped under "Non-feature work" with sub-entries)
+	// Render non-feature work grouped under "Non-feature work"
 	if len(nonFeatureTickets) > 0 {
 		sb.WriteString(fmt.Sprintf(`<li><strong>%s</strong>`, htmlNonFeatureWorkHeader))
-		sb.WriteString(`<ul>`)
 		for _, ticket := range nonFeatureTickets {
 			sb.WriteString(renderNonFeatureNextUpSubEntryHTML(ticket, tasks[ticket]))
 		}
-		sb.WriteString(`</ul></li>`)
+		sb.WriteString(`</li>`)
 	}
 
 	sb.WriteString(`</ul>`)
 	return sb.String()
 }
 
-// renderNextUpTicketEntryHTML renders a single next up ticket entry.
+// renderNextUpTicketEntryHTML renders a single next up ticket entry using inline <br/>.
 func renderNextUpTicketEntryHTML(ticket string, taskList []model.TaskWithDate, jiraInfo map[string]jira.TicketInfo) string {
 	sort.Slice(taskList, func(i, j int) bool {
 		return taskList[i].Date < taskList[j].Date
@@ -307,17 +309,16 @@ func renderNextUpTicketEntryHTML(ticket string, taskList []model.TaskWithDate, j
 		}
 	}
 
-	sb.WriteString(`<ul>`)
 	if mostRecentDesc != "" {
-		sb.WriteString(fmt.Sprintf(`<li>%s</li>`, html.EscapeString(mostRecentDesc)))
+		sb.WriteString(fmt.Sprintf(`<br/>%s%s`, bulletL2, html.EscapeString(mostRecentDesc)))
 	}
-	sb.WriteString(renderPRLinksHTML(prLinks))
-	sb.WriteString(`</ul></li>`)
+	sb.WriteString(renderPRLinksInline(prLinks, bulletL2))
+	sb.WriteString(`</li>`)
 
 	return sb.String()
 }
 
-// renderNonFeatureNextUpSubEntryHTML renders a non-feature next up sub-entry.
+// renderNonFeatureNextUpSubEntryHTML renders a non-feature next up sub-entry using <br/>.
 func renderNonFeatureNextUpSubEntryHTML(ticket string, taskList []model.TaskWithDate) string {
 	sort.Slice(taskList, func(i, j int) bool {
 		return taskList[i].Date < taskList[j].Date
@@ -344,21 +345,23 @@ func renderNonFeatureNextUpSubEntryHTML(ticket string, taskList []model.TaskWith
 	}
 
 	var sb strings.Builder
-	header := ticket
-	if header == "" {
-		header = "Misc"
-	}
-	sb.WriteString(fmt.Sprintf(`<li>%s`, html.EscapeString(header)))
 
-	if mostRecentDesc != "" || len(prLinks) > 0 {
-		sb.WriteString(`<ul>`)
+	// Determine header: for synthetic keys, use the upnext description
+	header := ticket
+	if IsSyntheticKey(ticket) || header == "" {
 		if mostRecentDesc != "" {
-			sb.WriteString(fmt.Sprintf(`<li>%s</li>`, html.EscapeString(mostRecentDesc)))
+			header = mostRecentDesc
+			mostRecentDesc = ""
+		} else {
+			header = "Misc"
 		}
-		sb.WriteString(renderPRLinksHTML(prLinks))
-		sb.WriteString(`</ul>`)
 	}
-	sb.WriteString(`</li>`)
+	sb.WriteString(fmt.Sprintf(`<br/>%s%s`, bulletL2, html.EscapeString(header)))
+
+	if mostRecentDesc != "" {
+		sb.WriteString(fmt.Sprintf(`<br/>%s%s`, bulletL3, html.EscapeString(mostRecentDesc)))
+	}
+	sb.WriteString(renderPRLinksInline(prLinks, bulletL3))
 
 	return sb.String()
 }
@@ -388,26 +391,22 @@ func renderBlockedTasksHTML(tasks []model.Task, jiraInfo map[string]jira.TicketI
 	// Render feature work first
 	for _, task := range featureTasks {
 		sb.WriteString(fmt.Sprintf(`<li><strong>%s</strong>`, jira.FormatTicketHTML(task.JiraTicket, jiraInfo)))
-		sb.WriteString(`<ul>`)
-		sb.WriteString(fmt.Sprintf(`<li>Blocker: %s</li>`, html.EscapeString(task.Blocker)))
-		sb.WriteString(`</ul></li>`)
+		sb.WriteString(fmt.Sprintf(`<br/>%sBlocker: %s`, bulletL2, html.EscapeString(task.Blocker)))
+		sb.WriteString(`</li>`)
 	}
 
-	// Render non-feature work at the end (grouped under "Non-feature work" with sub-entries)
+	// Render non-feature work grouped under "Non-feature work"
 	if len(nonFeatureTasks) > 0 {
 		sb.WriteString(fmt.Sprintf(`<li><strong>%s</strong>`, htmlNonFeatureWorkHeader))
-		sb.WriteString(`<ul>`)
 		for _, task := range nonFeatureTasks {
 			header := task.JiraTicket
 			if header == "" {
 				header = "Misc"
 			}
-			sb.WriteString(fmt.Sprintf(`<li>%s`, html.EscapeString(header)))
-			sb.WriteString(`<ul>`)
-			sb.WriteString(fmt.Sprintf(`<li>Blocker: %s</li>`, html.EscapeString(task.Blocker)))
-			sb.WriteString(`</ul></li>`)
+			sb.WriteString(fmt.Sprintf(`<br/>%s%s`, bulletL2, html.EscapeString(header)))
+			sb.WriteString(fmt.Sprintf(`<br/>&nbsp;&nbsp;&nbsp;%sBlocker: %s`, bulletL3, html.EscapeString(task.Blocker)))
 		}
-		sb.WriteString(`</ul></li>`)
+		sb.WriteString(`</li>`)
 	}
 
 	sb.WriteString(`</ul>`)

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -111,13 +111,6 @@ func printNonFeatureSubEntry(out io.Writer, ticket string, taskList []model.Task
 		return taskList[i].Date < taskList[j].Date
 	})
 
-	// Use ticket text as the sub-entry header (or "Misc" if empty)
-	header := ticket
-	if header == "" {
-		header = "Misc"
-	}
-	fmt.Fprintf(out, "        ◦ %s\n", header)
-
 	// Collect all descriptions and unique PR links
 	var descriptions []string
 	prLinks := make(map[string]bool)
@@ -129,7 +122,20 @@ func printNonFeatureSubEntry(out io.Writer, ticket string, taskList []model.Task
 		}
 	}
 
-	// Print all descriptions (third-level indent)
+	// Determine header: for synthetic keys, use the first description
+	header := ticket
+	if IsSyntheticKey(ticket) || header == "" {
+		if len(descriptions) > 0 {
+			header = descriptions[0]
+			descriptions = descriptions[1:]
+		} else {
+			header = "Misc"
+		}
+	}
+	fmt.Fprintf(out, "        ◦ %s\n", header)
+
+	// Print remaining descriptions (third-level indent), sorted
+	sort.Strings(descriptions)
 	for _, desc := range descriptions {
 		fmt.Fprintf(out, "            ▪ %s\n", desc)
 	}
@@ -249,13 +255,6 @@ func printNonFeatureNextUpSubEntry(out io.Writer, ticket string, taskList []mode
 		return taskList[i].Date < taskList[j].Date
 	})
 
-	// Use ticket text as the sub-entry header (or "Misc" if empty)
-	header := ticket
-	if header == "" {
-		header = "Misc"
-	}
-	fmt.Fprintf(out, "        ◦ %s\n", header)
-
 	// For next up tasks, only use the most recent entry per ticket
 	var mostRecentDesc string
 	prLinks := make(map[string]bool)
@@ -277,6 +276,18 @@ func printNonFeatureNextUpSubEntry(out io.Writer, ticket string, taskList []mode
 			prLinks[taskWithDate.GithubPR] = true
 		}
 	}
+
+	// Determine header: for synthetic keys, use the upnext description or first task description
+	header := ticket
+	if IsSyntheticKey(ticket) || header == "" {
+		if mostRecentDesc != "" {
+			header = mostRecentDesc
+			mostRecentDesc = "" // Don't duplicate as a nested bullet
+		} else {
+			header = "Misc"
+		}
+	}
+	fmt.Fprintf(out, "        ◦ %s\n", header)
 
 	// Print the most recent description (third-level indent)
 	if mostRecentDesc != "" {


### PR DESCRIPTION
## Summary
- Groups empty-ticket tasks by `github_pr` instead of merging all under "Misc", so each distinct work item gets its own sub-entry under Non-feature work
- Flattens HTML to use `<br/>` with unicode bullet characters (◦, -) instead of nested `<ul><li>`, which Slack strips when pasting from browser
- Adds `&nbsp;` indentation for visual hierarchy in Slack
- Sorts descriptions within non-feature sub-entries alphabetically

## Test plan
- [x] All existing tests pass with updated assertions
- [x] Verified HTML report renders correctly in browser
- [x] Verified copy-paste into Slack preserves bullets and indentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)